### PR TITLE
Fix error message in column model check

### DIFF
--- a/src/nespresso/db/repositories/checking.py
+++ b/src/nespresso/db/repositories/checking.py
@@ -10,7 +10,7 @@ def CheckColumnBelongsToModel(
 ) -> None:
     if column.property.parent.class_ is not model:
         raise ValueError(
-            "Provided column does not belong to the {model.__name__} model."
+            f"Provided column does not belong to the {model.__name__} model."
         )
 
 


### PR DESCRIPTION
## Summary
- correct missing f-string in CheckColumnBelongsToModel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68401d8235f08330bc03689e76d61e5b