### PR TITLE
Fix admin command help text

### DIFF
--- a/src/nespresso/bot/handlers/admin/commands/messages.py
+++ b/src/nespresso/bot/handlers/admin/commands/messages.py
@@ -21,7 +21,7 @@ async def CommandMessages(message: types.Message, command: CommandObject) -> Non
     if not command.args or len(command.args.split()) != 2:  # noqa: PLR2004
         await SendMessage(
             chat_id=message.chat.id,
-            text="Iclude tg username and limit:\n/messages @vbalab 15",
+            text="Include tg username and limit:\n/messages @vbalab 15",
             context=MessageContext.UserFailed,
         )
         return

--- a/src/nespresso/bot/handlers/admin/commands/send.py
+++ b/src/nespresso/bot/handlers/admin/commands/send.py
@@ -28,7 +28,7 @@ async def CommandSend(
     if not command.args or len(command.args.split()) != 1:
         await SendMessage(
             chat_id=message.chat.id,
-            text="Iclude tg username:\n/send @vbalab",
+            text="Include tg username:\n/send @vbalab",
             context=MessageContext.UserFailed,
         )
         return


### PR DESCRIPTION
## Summary
- correct typos in admin help messages

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401f0176e48330b8a3197bce6c4499